### PR TITLE
Remove deployment step from frontend workflow

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -38,16 +38,3 @@ jobs:
         run: |
           cd frontend
           npm run test
-
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy on server
-        uses: appleboy/ssh-action@v0.1.8
-        with:
-          host: ${{ vars.SSH_HOST }}
-          username: ${{ vars.SSH_USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          script: |
-            cd ${{ vars.BUILD_PATH }}/frontend
-            sudo sh build.sh


### PR DESCRIPTION
Remove SSH deployment from workflow

- Removed manual deployment step that requires SSH key
- Deployment now handled automatically by Vercel, [link to the dashboard here](https://vercel.com/filecoin-foundations-projects/on-chain-voting)